### PR TITLE
fix: auto detect secure protocol bindings

### DIFF
--- a/src/wot-thing.html
+++ b/src/wot-thing.html
@@ -17,7 +17,7 @@
                             if (parsed.protocol !== null) {
                                 // remove trailing ':'
                                 const scheme = parsed.protocol.slice(0, -1);
-                                return (scheme === binding) ? true : false;
+                                return scheme === binding || scheme === binding + "s";
                             }
                         });
                         if (check)


### PR DESCRIPTION
Recently I've made a feature of automatic protocol binding detection.
However, I've found an issue when secure protocols (e.g. https or coaps) were not resolved properly.
This PR fixes that.

Signed-off-by: fatadel <fatadel@gmail.com>