### PR TITLE
Update node-wot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     }
   },
   "dependencies": {
-    "@node-wot/core": "0.7.3",
-    "@node-wot/binding-http": "0.7.3",
-    "@node-wot/binding-coap": "0.7.3",
-    "@node-wot/binding-mqtt": "0.7.3",
-    "@node-wot/binding-opcua": "0.7.3",
-    "@node-wot/binding-modbus": "0.7.3"
+    "@node-wot/binding-coap": "0.7.5",
+    "@node-wot/binding-http": "0.7.5",
+    "@node-wot/binding-modbus": "0.7.5",
+    "@node-wot/binding-mqtt": "0.7.5",
+    "@node-wot/binding-opcua": "0.7.5",
+    "@node-wot/core": "0.7.5"
   }
 }


### PR DESCRIPTION
As a new version of `node-wot` has been published to npm, this PR updates the `node-wot` dependencies in `package.json`. In particular, this change enables the use of IPv6, which was not possible before.